### PR TITLE
feat(paseto): add Paseto v3/decrypt and testsImport and wire Pas v3 implementation into the main gaseto API and

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,18 @@
 
 PASETO is a specification for secure stateless tokens. Unlike JWT, which gives developers too many choices, PASETO specifies a small number of cryptographic suites to use.
 
+> **Note:** This library targets the Erlang runtime only. JavaScript is not supported.
+
 ### 🚧 This project is in construction. Not production ready 🚧
 
 ## Features
 
-- PASETO v1
+- **PASETO V3** _(recommended)_
+  - `v3.local`: Symmetric authenticated encryption using AES-256-CTR and HMAC-SHA-384, with HKDF-SHA-384 key derivation.
+  - `v3.public`: Asymmetric authentication using ECDSA with P-384 and SHA-384.
+- **PASETO V1** _(deprecated — the PASETO standard itself has deprecated V1 in favour of V3)_
   - `v1.local`: Symmetric authenticated encryption using AES-256-CTR and HMAC-SHA-384.
   - `v1.public`: Asymmetric authentication using RSA-PSS with SHA-384.
-
-_Before V1:_
-
-- [ ] PASETO V2 support
-- [ ] PASERK key conversion
-
-_After V1:_
-
-- [ ] PASETO V3/V4 support
 
 ## Installation
 
@@ -32,35 +28,44 @@ gleam add gaseto
 
 ## Usage
 
-Here's an example of how to create and verify a `v1.local` PASETO token.
+Here's an example of how to create and verify a `v3.local` PASETO token:
 
 ```gleam
-import gleam/result
 import gleam/option.{None}
-import gaseto
+import gaseto.{LocalKey}
 import gaseto/token
 
 pub fn main() {
-  let key = "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f"
-  let payload = "{"data":"this is a signed message","exp":"2019-01-01T00:00:00+00:00"}"
+  let key = LocalKey("707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f")
+  let payload = "{\"data\":\"this is a signed message\",\"exp\":\"2019-01-01T00:00:00+00:00\"}"
 
-  // Create a token
-  let assert Ok(encrypted_token) =
-    gaseto.encrypt(
-      payload,
-      key,
-      token.PasetoV1,
-      token.Local,
-      None,
-    )
-
+  let assert Ok(encrypted_token) = gaseto.encrypt(payload, key, token.PasetoV3, None)
   let token_string = gaseto.to_string(encrypted_token)
+  let assert Ok(decrypted_token) = gaseto.decrypt(token_string, key)
 
-  // Verify the token
-  let assert Ok(decrypted_token) =
-    gaseto.decrypt(token_string, key)
+  let assert True = decrypted_token.payload == payload
+}
+```
 
-  assert decrypted_token.payload == payload
+For `v3.public`, use a `KeyPair`:
+
+```gleam
+import gleam/option.{None}
+import gaseto.{KeyPair}
+import gaseto/token
+
+pub fn main() {
+  let key = KeyPair(
+    secret_key: "...",  // 48-byte P-384 private scalar, hex-encoded
+    public_key: "...",  // 49-byte compressed P-384 point, hex-encoded
+  )
+  let payload = "{\"data\":\"hello\",\"exp\":\"2025-01-01T00:00:00+00:00\"}"
+
+  let assert Ok(signed_token) = gaseto.encrypt(payload, key, token.PasetoV3, None)
+  let token_string = gaseto.to_string(signed_token)
+  let assert Ok(verified) = gaseto.decrypt(token_string, key)
+
+  let assert True = verified.payload == payload
 }
 ```
 
@@ -69,7 +74,5 @@ Further documentation can be found at <https://hexdocs.pm/gaseto>.
 ## Development
 
 ```sh
-gleam run   # Run the project
 gleam test  # Run the tests
 ```
-

--- a/doc/ecdsa-p384.md
+++ b/doc/ecdsa-p384.md
@@ -1,0 +1,42 @@
+# ECDSA P-384 in PASETO V3
+
+## ECDSA
+
+ECDSA (Elliptic Curve Digital Signature Algorithm) is a digital signature scheme
+based on elliptic curve cryptography. Signing produces a signature that anyone
+holding the corresponding public key can verify, without being able to forge new
+signatures.
+
+## P-384
+
+P-384 (also known as secp384r1 or NIST P-384) is a specific elliptic curve
+standardised by NIST. Its key sizes — 48-byte private scalar, 49-byte compressed
+public point — give a 192-bit security level, which PASETO V3 requires.
+
+The public key is stored in **compressed form**: a single prefix byte (`0x02` or
+`0x03`, indicating whether the Y coordinate is even or odd) followed by the
+48-byte X coordinate, for a total of 49 bytes.
+
+## SHA-384
+
+SHA-384 is the hash function used during signing and verification. The message is
+hashed before the elliptic curve math, so the signature covers a fixed-size
+digest rather than the raw message bytes.
+
+## Signature formats: DER vs. IEEE P1363
+
+An ECDSA signature consists of two large integers, conventionally called `r` and
+`s`. There are two common ways to encode them as bytes:
+
+**DER (Distinguished Encoding Rules):** A variable-length ASN.1 format used by
+most cryptographic libraries and TLS. Each integer is length-prefixed, and a
+leading `0x00` byte is added when the high bit of `r` or `s` would otherwise
+look like a negative sign. This is what Erlang's `crypto` module produces and
+consumes.
+
+**IEEE P1363:** A fixed-length format used by PASETO and many web standards
+(e.g. JSON Web Signatures). `r` and `s` are each zero-padded to exactly 48 bytes
+and concatenated, giving a flat 96-byte signature with no length fields.
+
+Because Erlang's `crypto` module works in DER and PASETO requires P1363, the
+`ecdsa` module converts between the two formats on every sign and verify call.

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,6 @@
 name = "gaseto"
 version = "0.0.1"
+target = "erlang"
 
 # Fill out these fields if you intend to generate HTML documentation or publish
 # your project to the Hex package manager.

--- a/manifest.toml
+++ b/manifest.toml
@@ -4,8 +4,8 @@
 packages = [
   { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
-  { name = "gleam_stdlib", version = "0.62.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "0080706D3A5A9A36C40C68481D1D231D243AF602E6D2A2BE67BA8F8F4DFF45EC" },
-  { name = "gleeunit", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "FDC68A8C492B1E9B429249062CD9BAC9B5538C6FBF584817205D0998C42E1DAC" },
+  { name = "gleam_stdlib", version = "0.70.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86949BF5D1F0E4AC0AB5B06F235D8A5CC11A2DFC33BF22F752156ED61CA7D0FF" },
+  { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
   { name = "hkdf_erlang", version = "1.0.0", build_tools = ["rebar3"], requirements = [], otp_app = "hkdf_erlang", source = "hex", outer_checksum = "D2091D9E0DF97613FD149074929A94E3675047F28CCA6B1626FE7BE60F5D76AC" },
 ]
 

--- a/src/gaseto.gleam
+++ b/src/gaseto.gleam
@@ -1,7 +1,8 @@
 import gaseto/paseto_v1
+import gaseto/paseto_v3
 import gaseto/token.{
-  type PasetoPurpose, type PasetoVersion, type Token, Local, PasetoV1, PasetoV2,
-  PasetoV3, PasetoV4, Public,
+  type PasetoVersion, type Token, Local, PasetoV1, PasetoV2, PasetoV3, PasetoV4,
+  Public,
 }
 import gleam/option.{type Option}
 import gleam/result
@@ -13,6 +14,13 @@ pub type Error {
   EncodeTokenError
   DecodeTokenError(message: String)
   NotImplementedError
+}
+
+/// The key material passed to encrypt and decrypt.
+/// Use LocalKey for symmetric local tokens and KeyPair for asymmetric public tokens.
+pub type Key {
+  LocalKey(key: String)
+  KeyPair(secret_key: String, public_key: String)
 }
 
 pub fn to_string(token: Token) -> String {
@@ -27,51 +35,75 @@ pub fn to_string(token: Token) -> String {
   }
 }
 
-pub fn decrypt(token: String, decode_key: String) -> Result(Token, Error) {
-  use
-    #(version, purpose, payload, footer): #(
-      String,
-      String,
-      String,
-      option.Option(String),
-    )
-  <- result.try(parse_token_parts(token))
-  use paseto_version <- result.try(parse_paseto_version(version))
-  use paseto_purpose <- result.try(parse_paseto_purpose(purpose))
-
-  case paseto_version {
-    PasetoV4 -> Error(NotImplementedError)
-    PasetoV3 -> Error(NotImplementedError)
-    PasetoV2 -> Error(NotImplementedError)
-    PasetoV1 -> {
-      case paseto_v1.decrypt(paseto_purpose, payload, footer, decode_key) {
+/// Encrypts or signs a payload depending on the key type.
+/// LocalKey produces a local (encrypted) token; KeyPair produces a public (signed) token.
+pub fn encrypt(
+  payload: String,
+  with_key: Key,
+  with_version: PasetoVersion,
+  with_footer: Option(String),
+) -> Result(Token, Error) {
+  case with_version, with_key {
+    PasetoV1, LocalKey(key) ->
+      case paseto_v1.encrypt(Local, key, payload, with_footer) {
         Ok(token) -> Ok(token)
-        Error(error) -> {
-          Error(DecodeTokenError("Neij"))
-        }
+        Error(_e) -> Error(EncodeTokenError)
       }
-    }
+    PasetoV1, KeyPair(secret_key, _) ->
+      case paseto_v1.encrypt(Public, secret_key, payload, with_footer) {
+        Ok(token) -> Ok(token)
+        Error(_e) -> Error(EncodeTokenError)
+      }
+    PasetoV3, LocalKey(key) ->
+      case paseto_v3.encrypt(Local, key, payload, with_footer) {
+        Ok(token) -> Ok(token)
+        Error(_e) -> Error(EncodeTokenError)
+      }
+    PasetoV3, KeyPair(secret_key, public_key) ->
+      case
+        paseto_v3.encrypt_public(secret_key, public_key, payload, with_footer, "")
+      {
+        Ok(token) -> Ok(token)
+        Error(_e) -> Error(EncodeTokenError)
+      }
+    _, _ -> Error(NotImplementedError)
   }
 }
 
-pub fn encrypt(
-  payload: String,
-  with_key: String,
-  with_version: PasetoVersion,
-  with_purpose: PasetoPurpose,
-  with_footer: Option(String),
-) -> Result(Token, Error) {
-  case with_version {
-    PasetoV1 ->
-      case paseto_v1.encrypt(with_purpose, with_key, payload, with_footer) {
+/// Decrypts or verifies a token depending on the key type.
+/// LocalKey is used for local tokens; KeyPair uses the public_key for verification.
+pub fn decrypt(token: String, with_key: Key) -> Result(Token, Error) {
+  use #(version, purpose, payload, footer): #(
+    String,
+    String,
+    String,
+    option.Option(String),
+  ) <- result.try(parse_token_parts(token))
+  use paseto_version <- result.try(parse_paseto_version(version))
+  use paseto_purpose <- result.try(parse_paseto_purpose(purpose))
+
+  case paseto_version, with_key {
+    PasetoV1, LocalKey(key) ->
+      case paseto_v1.decrypt(paseto_purpose, payload, footer, key) {
         Ok(token) -> Ok(token)
-        Error(e) -> {
-          Error(EncodeTokenError)
-        }
+        Error(_e) -> Error(DecodeTokenError("V1 decryption failed"))
       }
-    PasetoV2 -> Error(NotImplementedError)
-    PasetoV3 -> Error(NotImplementedError)
-    PasetoV4 -> Error(NotImplementedError)
+    PasetoV1, KeyPair(_, public_key) ->
+      case paseto_v1.decrypt(paseto_purpose, payload, footer, public_key) {
+        Ok(token) -> Ok(token)
+        Error(_e) -> Error(DecodeTokenError("V1 verification failed"))
+      }
+    PasetoV3, LocalKey(key) ->
+      case paseto_v3.decrypt(paseto_purpose, payload, footer, key, "") {
+        Ok(token) -> Ok(token)
+        Error(_e) -> Error(DecodeTokenError("V3 decryption failed"))
+      }
+    PasetoV3, KeyPair(_, public_key) ->
+      case paseto_v3.decrypt(paseto_purpose, payload, footer, public_key, "") {
+        Ok(token) -> Ok(token)
+        Error(_e) -> Error(DecodeTokenError("V3 verification failed"))
+      }
+    _, _ -> Error(NotImplementedError)
   }
 }
 
@@ -105,14 +137,14 @@ fn paseto_version_to_string(version: PasetoVersion) -> String {
   }
 }
 
-fn paseto_purpose_to_string(purpose: PasetoPurpose) -> String {
+fn paseto_purpose_to_string(purpose: token.PasetoPurpose) -> String {
   case purpose {
     Public -> "public"
     Local -> "local"
   }
 }
 
-fn parse_paseto_purpose(purpose: String) -> Result(PasetoPurpose, Error) {
+fn parse_paseto_purpose(purpose: String) -> Result(token.PasetoPurpose, Error) {
   case string.lowercase(purpose) {
     "local" -> Ok(Local)
     "public" -> Ok(Public)

--- a/src/gaseto/ecdsa.gleam
+++ b/src/gaseto/ecdsa.gleam
@@ -1,0 +1,145 @@
+//// ECDSA P-384 + SHA-384 signing and verification for PASETO V3 public tokens.
+////
+//// Erlang's `crypto` module produces DER-encoded signatures, while PASETO requires
+//// the flat IEEE P1363 format (r || s, 96 bytes). This module handles the conversion.
+////
+//// See `doc/ecdsa-p384.md` for background on the algorithms and formats involved.
+
+import gleam/bit_array
+import gleam/result
+
+/// Signs data using ECDSA with P-384 and SHA-384.
+/// Returns the DER-encoded signature from Erlang's crypto module.
+@external(erlang, "gaseto_ecdsa_ffi", "sign_p384")
+fn crypto_sign_p384(data: BitArray, private_key: BitArray) -> BitArray
+
+/// Verifies a DER-encoded ECDSA P-384 + SHA-384 signature
+@external(erlang, "gaseto_ecdsa_ffi", "verify_p384")
+fn crypto_verify_p384(
+  data: BitArray,
+  der_signature: BitArray,
+  public_key: BitArray,
+) -> Bool
+
+/// Signs data using ECDSA with P-384 curve and SHA-384.
+/// Returns the signature in IEEE P1363 format
+pub fn sign_p384(
+  data: BitArray,
+  private_key: BitArray,
+) -> Result(BitArray, String) {
+  crypto_sign_p384(data, private_key) |> der_to_p1363()
+}
+
+/// Verifies an ECDSA P-384 + SHA-384 signature.
+/// Expects the signature in IEEE P1363 format.
+/// The public key should be in compressed form (49 bytes: 02/03 prefix + 48-byte X).
+pub fn verify_p384(
+  data: BitArray,
+  p1363_signature: BitArray,
+  public_key: BitArray,
+) -> Bool {
+  case p1363_to_der(p1363_signature) {
+    Error(_) -> False
+    Ok(der_signature) -> crypto_verify_p384(data, der_signature, public_key)
+  }
+}
+
+/// Converts a DER-encoded ECDSA signature to IEEE P1363 format.
+/// DER format: 30 <total_length> 02 <r_length> <r_bytes> 02 <s_length> <s_bytes>
+/// P1363 format: r (48 bytes, big-endian) || s (48 bytes, big-endian)
+fn der_to_p1363(der: BitArray) -> Result(BitArray, String) {
+  case der {
+    <<0x30, _total_length, 0x02, r_length, r_and_s_section:bytes>> -> {
+      use r_raw_bytes <- result.try(
+        bit_array.slice(r_and_s_section, 0, r_length)
+        |> result.map_error(fn(_) { "Could not extract r from DER" }),
+      )
+      let s_start_offset = r_length
+      let r_and_s_section_size = bit_array.byte_size(r_and_s_section)
+      use s_section <- result.try(
+        bit_array.slice(
+          r_and_s_section,
+          s_start_offset,
+          r_and_s_section_size - s_start_offset,
+        )
+        |> result.map_error(fn(_) { "Could not extract s header from DER" }),
+      )
+      case s_section {
+        <<0x02, s_length, s_raw_section:bytes>> -> {
+          use s_raw_bytes <- result.try(
+            bit_array.slice(s_raw_section, 0, s_length)
+            |> result.map_error(fn(_) { "Could not extract s from DER" }),
+          )
+          Ok(bit_array.append(
+            normalize_to_48(r_raw_bytes),
+            normalize_to_48(s_raw_bytes),
+          ))
+        }
+        _ -> Error("Invalid S INTEGER in DER signature")
+      }
+    }
+    _ -> Error("Invalid DER ECDSA signature format")
+  }
+}
+
+/// Pads or trims a big-endian integer to exactly 48 bytes by
+/// either removing leading zeros or adding them
+fn normalize_to_48(value: BitArray) -> BitArray {
+  let byte_count = bit_array.byte_size(value)
+  case byte_count {
+    count if count > 48 -> {
+      case bit_array.slice(value, count - 48, 48) {
+        Ok(trimmed) -> trimmed
+        Error(_) -> value
+      }
+    }
+    48 -> value
+    count -> {
+      let padding_bits = { 48 - count } * 8
+      bit_array.append(<<0:size(padding_bits)>>, value)
+    }
+  }
+}
+
+/// Converts a 96-byte IEEE P1363 signature (r || s) to DER format
+fn p1363_to_der(p1363_signature: BitArray) -> Result(BitArray, String) {
+  case bit_array.byte_size(p1363_signature) {
+    96 -> {
+      use r_component: BitArray <- result.try(
+        bit_array.slice(p1363_signature, 0, 48)
+        |> result.map_error(fn(_) { "Could not slice r from P1363" }),
+      )
+      use s_component: BitArray <- result.try(
+        bit_array.slice(p1363_signature, 48, 48)
+        |> result.map_error(fn(_) { "Could not slice s from P1363" }),
+      )
+      let r_der_integer: BitArray = encode_der_integer(r_component)
+      let s_der_integer: BitArray = encode_der_integer(s_component)
+      let der_inner: BitArray = bit_array.append(r_der_integer, s_der_integer)
+      let inner_length: Int = bit_array.byte_size(der_inner)
+      Ok(<<0x30, inner_length, der_inner:bits>>)
+    }
+    _ -> Error("P1363 signature must be 96 bytes for P-384")
+  }
+}
+
+/// Encodes a big-endian integer as a DER INTEGER element (tag 0x02)
+fn encode_der_integer(raw_integer: BitArray) -> BitArray {
+  let stripped_integer: BitArray = strip_leading_zeros(raw_integer)
+  let sign_padded_integer: BitArray = case stripped_integer {
+    <<>> -> <<0>>
+    <<high_byte, _:bytes>> if high_byte >= 128 ->
+      bit_array.append(<<0>>, stripped_integer)
+    _ -> stripped_integer
+  }
+  let integer_length: Int = bit_array.byte_size(sign_padded_integer)
+  <<0x02, integer_length, sign_padded_integer:bits>>
+}
+
+/// Strips all leading 0x00 bytes from a bit array.
+fn strip_leading_zeros(data: BitArray) -> BitArray {
+  case data {
+    <<0, rest:bytes>> -> strip_leading_zeros(rest)
+    _ -> data
+  }
+}

--- a/src/gaseto/pae.gleam
+++ b/src/gaseto/pae.gleam
@@ -1,0 +1,49 @@
+//// PASETO Pre-Authentication Encoding (PAE) and token encoding utilities
+//// shared across all PASETO versions.
+////
+//// PAE is defined in the PASETO spec as a deterministic encoding of a list
+//// of byte strings into a single byte string for authentication. Every PASETO
+//// version uses the same PAE algorithm.
+
+import gleam/bit_array
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/result
+
+/// Encodes a list of byte strings as a single authenticated message using
+/// PASETO Pre-Authentication Encoding (PAE).
+pub fn pre_auth_encode(parts: List(BitArray)) -> BitArray {
+  let start: BitArray = le64_encode(list.length(parts))
+  list.fold(parts, start, fn(accumulator, part) {
+    let part_length: Int = bit_array.byte_size(part)
+    bit_array.concat([accumulator, le64_encode(part_length), part])
+  })
+}
+
+/// Decodes an optional base64url-encoded footer to raw bytes.
+/// Returns a plain String error so callers can map it into their own error type.
+pub fn decode_footer(
+  encoded_footer: Option(String),
+) -> Result(BitArray, String) {
+  result.map_error(
+    case encoded_footer {
+      Some(footer_string) -> bit_array.base64_url_decode(footer_string)
+      None -> Ok(<<>>)
+    },
+    fn(_) { "Token footer is not valid base64url" },
+  )
+}
+
+/// Converts raw footer bytes back to an optional string, treating empty as None.
+pub fn footer_bytes_to_option(footer_bytes: BitArray) -> Option(String) {
+  case bit_array.to_string(footer_bytes) {
+    Ok("") -> None
+    Ok(footer_string) -> Some(footer_string)
+    Error(_) -> None
+  }
+}
+
+/// Encodes an integer as an 8-byte little-endian value.
+fn le64_encode(value: Int) -> BitArray {
+  <<value:little-size(64)>>
+}

--- a/src/gaseto/paseto_v1.gleam
+++ b/src/gaseto/paseto_v1.gleam
@@ -1,5 +1,6 @@
 import gaseto/crypto as gaseto_crypto
 import gaseto/hkdf
+import gaseto/pae
 import gaseto/rsa
 import gaseto/token.{
   type PasetoPurpose, type Token, Local, PasetoV1, Public, Token,
@@ -9,7 +10,6 @@ import gleam/crypto
 import gleam/dynamic.{type Dynamic}
 import gleam/erlang/atom
 import gleam/int
-import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/result
 
@@ -54,13 +54,9 @@ fn decrypt_public(
   use decoded_body <- result.try(decode_body(encoded_body))
 
   use footer_bits: BitArray <- result.try(
-    result.map_error(
-      case encoded_footer {
-        Some(f) -> bit_array.base64_url_decode(f)
-        None -> Ok(<<>>)
-      },
-      fn(_) { InvalidTokenFormat("Token Footer is not base64") },
-    ),
+    result.map_error(pae.decode_footer(encoded_footer), fn(message) {
+      InvalidTokenFormat(message)
+    }),
   )
   use public_key <- result.try({
     let pem_entries =
@@ -105,7 +101,7 @@ fn decrypt_public(
 
   // Reconstruct the `m2` that should have been signed.
   let m2: BitArray =
-    pre_auth_encode([
+    pae.pre_auth_encode([
       bit_array.from_string(pub_header),
       payload_bits,
       footer_bits,
@@ -120,11 +116,7 @@ fn decrypt_public(
       create_pss_options(),
     )
 
-  let footer = case bit_array.to_string(footer_bits) {
-    Ok("") -> None
-    Ok(result) -> Some(result)
-    Error(_) -> None
-  }
+  let footer: Option(String) = pae.footer_bytes_to_option(footer_bits)
 
   use payload <- result.try(case bit_array.to_string(payload_bits) {
     Ok(result) -> Ok(result)
@@ -164,13 +156,9 @@ fn decrypt_local(
   use decoded_body <- result.try(decode_body(encoded_body))
 
   use footer_bits: BitArray <- result.try(
-    result.map_error(
-      case encoded_footer {
-        Some(f) -> bit_array.base64_url_decode(f)
-        None -> Ok(<<>>)
-      },
-      fn(_) { InvalidTokenFormat("Token Footer is not base64") },
-    ),
+    result.map_error(pae.decode_footer(encoded_footer), fn(message) {
+      InvalidTokenFormat(message)
+    }),
   )
 
   // PASETO v1 local structure: nonce (32) + ciphertext + tag (48)
@@ -216,7 +204,7 @@ fn decrypt_local(
 
   // Verify HMAC-SHA384 authentication
   let pre_auth_data =
-    pre_auth_encode([
+    pae.pre_auth_encode([
       bit_array.from_string(priv_header),
       nonce,
       ciphertext,
@@ -244,11 +232,7 @@ fn decrypt_local(
     ciphertext,
   ))
 
-  let footer = case bit_array.to_string(footer_bits) {
-    Ok("") -> None
-    Ok(result) -> Some(result)
-    Error(_) -> None
-  }
+  let footer: Option(String) = pae.footer_bytes_to_option(footer_bits)
 
   use payload <- result.try(case bit_array.to_string(plaintext) {
     Ok(result) -> Ok(result)
@@ -446,7 +430,7 @@ fn encrypt_public(
   let pem_bytes: BitArray = bit_array.from_string(private_key_pem)
   use private_key <- result.try(decode_private_key(pem_bytes))
   let pre_authentication: BitArray =
-    pre_auth_encode([
+    pae.pre_auth_encode([
       bit_array.from_string(pub_header),
       payload_bits,
       footer_bits,
@@ -578,7 +562,7 @@ fn aead_encrypt(
     )
 
   let pre_authentication: BitArray =
-    pre_auth_encode([
+    pae.pre_auth_encode([
       bit_array.from_string(header),
       nonce,
       ciphertext,
@@ -598,45 +582,3 @@ fn aead_encrypt(
   Ok(Token(PasetoV1, Local, body_base64, footer_string))
 }
 
-/// Pre-authenticates a list of bit arrays for PASETO.
-///
-/// This function implements the PASETO `PAE` (pre-authentication encoding) scheme.
-/// It prepends the length of the list, followed by the length of each element,
-/// and then the elements themselves. This ensures that the message is authenticated
-/// in a deterministic and secure way, preventing malicious modifications.
-///
-/// ## Parameters
-///
-/// - `parts`: A `List(BitArray)` of the token's components (e.g., header, payload, footer).
-///
-/// ## Returns
-///
-/// The single `BitArray` resulting from the pre-authentication encoding.
-fn pre_auth_encode(parts: List(BitArray)) -> BitArray {
-  let start = le64_encode(list.length(parts))
-  list.fold(parts, start, fn(acc, part) {
-    let part_len = bit_array.byte_size(part)
-    bit_array.concat([acc, le64_encode(part_len), part])
-  })
-}
-
-/// Encodes an integer as an 8-byte little-endian bit array.
-///
-/// This function is a helper for the PASETO `PAE` scheme, which requires integer
-/// lengths to be encoded in a fixed-size, little-endian format. It's equivalent
-/// to a 64-bit unsigned integer (`u64`).
-///
-/// ## Parameters
-///
-/// - `value`: The integer to encode.
-///
-/// ## Returns
-///
-/// The encoded integer as an 8-byte `BitArray`.
-fn le64_encode(value: Int) -> BitArray {
-  list.range(0, 7)
-  |> list.map(fn(i) {
-    <<int.bitwise_and(int.bitwise_shift_right(value, i * 8), 255)>>
-  })
-  |> bit_array.concat()
-}

--- a/src/gaseto/paseto_v3.gleam
+++ b/src/gaseto/paseto_v3.gleam
@@ -1,0 +1,535 @@
+import gaseto/crypto as gaseto_crypto
+import gaseto/ecdsa
+import gaseto/hkdf
+import gaseto/pae
+import gaseto/token.{
+  type PasetoPurpose, type Token, Local, PasetoV3, Public, Token,
+}
+import gleam/bit_array
+import gleam/crypto
+import gleam/erlang/atom
+import gleam/int
+import gleam/option.{type Option, None, Some}
+import gleam/result
+
+const local_header: String = "v3.local."
+
+const public_header: String = "v3.public."
+
+// V3.local sizes
+const local_master_key_size: Int = 32
+
+const local_nonce_size: Int = 32
+
+const local_tag_size: Int = 48
+
+// Encryption key material is derived as a single HKDF output that is then
+// split into the encryption key (32 bytes) and the counter nonce (16 bytes).
+const local_encryption_key_material_size: Int = 48
+
+const local_encryption_key_size: Int = 32
+
+const local_counter_nonce_size: Int = 16
+
+// V3.public sizes
+const public_secret_key_size: Int = 48
+
+const public_key_size: Int = 49
+
+// P-384 P1363 signature: r (48 bytes) || s (48 bytes)
+const public_signature_size: Int = 96
+
+pub type GasetoV3Error {
+  InvalidTokenType(message: String)
+  UnexpectedEncryptionError(message: String)
+  HkdfError(message: String)
+  InvalidKeyFormat(message: String)
+  EcdsaError(message: String)
+}
+
+pub type PasetoV3DecryptError {
+  VerificationFailed(message: String)
+  InvalidTokenFormat(message: String)
+  InvalidKey(message: String)
+  SecurityError
+  CryptographicError(message: String)
+  UnexpectedDecryptionError(message: String)
+}
+
+/// Routes encryption to the appropriate V3 scheme.
+/// Note: V3.public requires both secret and public keys — use encrypt_public directly.
+pub fn encrypt(
+  purpose: PasetoPurpose,
+  key: String,
+  payload: String,
+  footer: Option(String),
+) -> Result(Token, GasetoV3Error) {
+  case purpose {
+    Local -> {
+      let nonce: BitArray = crypto.strong_random_bytes(32)
+      encrypt_local(key, payload, footer, nonce, "")
+    }
+    Public ->
+      Error(InvalidTokenType(
+        "V3 public signing requires both secret and public keys; use encrypt_public directly",
+      ))
+  }
+}
+
+/// Routes decryption to the appropriate V3 scheme.
+/// For V3.public, key should be the hex-encoded compressed P-384 public key (49 bytes = 98 hex chars).
+pub fn decrypt(
+  purpose: PasetoPurpose,
+  payload: String,
+  footer: Option(String),
+  key: String,
+  implicit_assertion: String,
+) -> Result(Token, PasetoV3DecryptError) {
+  case purpose {
+    Local -> decrypt_local(key, payload, footer, implicit_assertion)
+    Public -> decrypt_public(key, payload, footer, implicit_assertion)
+  }
+}
+
+/// Encrypts a payload using V3.local (AES-256-CTR + HMAC-SHA384).
+/// The nonce parameter allows injecting a deterministic nonce for testing.
+pub fn encrypt_local(
+  shared_secret: String,
+  plaintext_payload: String,
+  footer: Option(String),
+  nonce: BitArray,
+  implicit_assertion: String,
+) -> Result(Token, GasetoV3Error) {
+  use master_key: BitArray <- result.try(
+    result.map_error(bit_array.base16_decode(shared_secret), fn(_) {
+      InvalidKeyFormat("Could not hex-decode secret key")
+    }),
+  )
+  use _ <- result.try(case bit_array.byte_size(master_key) {
+    size if size == local_master_key_size -> Ok(Nil)
+    size ->
+      Error(InvalidKeyFormat(
+        "Key must be 32 bytes, got " <> int.to_string(size),
+      ))
+  })
+  let footer_bytes: BitArray = case footer {
+    Some("") -> <<>>
+    None -> <<>>
+    Some(footer_string) -> bit_array.from_string(footer_string)
+  }
+  aead_encrypt(
+    plaintext_payload,
+    master_key,
+    footer_bytes,
+    nonce,
+    footer,
+    implicit_assertion,
+  )
+}
+
+fn aead_encrypt(
+  plaintext_payload: String,
+  master_key: BitArray,
+  footer_bytes: BitArray,
+  nonce: BitArray,
+  footer: Option(String),
+  implicit_assertion: String,
+) -> Result(Token, GasetoV3Error) {
+  use #(encryption_key, counter_nonce, authentication_key) <- result.try(
+    result.map_error(derive_local_keys(master_key, nonce), fn(message) {
+      HkdfError(message)
+    }),
+  )
+
+  // Encrypt with AES-256-CTR
+  let ciphertext: BitArray =
+    gaseto_crypto.crypto_one_time(
+      atom.create("aes_256_ctr"),
+      encryption_key,
+      counter_nonce,
+      bit_array.from_string(plaintext_payload),
+      True,
+    )
+
+  // Compute HMAC-SHA384 over PAE(header, nonce, ciphertext, footer, implicit_assertion).
+  // V3 PAE has 5 parts (includes implicit assertion, unlike V1 which has 4).
+  let pre_authentication_data: BitArray =
+    pae.pre_auth_encode([
+      bit_array.from_string(local_header),
+      nonce,
+      ciphertext,
+      footer_bytes,
+      bit_array.from_string(implicit_assertion),
+    ])
+  let authentication_tag: BitArray =
+    crypto.hmac(pre_authentication_data, crypto.Sha384, authentication_key)
+
+  let token_body_bytes: BitArray =
+    bit_array.concat([nonce, ciphertext, authentication_tag])
+  let token_body_base64: String =
+    bit_array.base64_url_encode(token_body_bytes, False)
+  let token_footer_base64: Option(String) = case footer_bytes {
+    <<>> -> None
+    _ -> Some(bit_array.base64_url_encode(footer_bytes, False))
+  }
+  let _ = footer
+  Ok(Token(PasetoV3, Local, token_body_base64, token_footer_base64))
+}
+
+/// Decrypts a V3.local token.
+/// encoded_body is the base64url-encoded payload section (without the "v3.local." header).
+/// encoded_footer is the base64url-encoded footer (without the dot separator).
+pub fn decrypt_local(
+  raw_key: String,
+  encoded_body: String,
+  encoded_footer: Option(String),
+  implicit_assertion: String,
+) -> Result(Token, PasetoV3DecryptError) {
+  use master_key: BitArray <- result.try(
+    result.map_error(bit_array.base16_decode(raw_key), fn(_) {
+      InvalidKey("Could not hex-decode secret key")
+    }),
+  )
+  use _ <- result.try(case bit_array.byte_size(master_key) {
+    size if size == local_master_key_size -> Ok(Nil)
+    size ->
+      Error(InvalidKey("Key must be 32 bytes, got " <> int.to_string(size)))
+  })
+  use decoded_body: BitArray <- result.try(
+    result.map_error(bit_array.base64_url_decode(encoded_body), fn(_) {
+      InvalidTokenFormat("Token body is not valid base64url")
+    }),
+  )
+  // Strict base64url validation: re-encode the decoded bytes and verify they
+  // match the original string. This catches tokens where the trailing padding
+  // bits of the last base64url character are non-zero — a sign of tampering or
+  // a non-canonical encoding that a lenient decoder would silently accept.
+  use _ <- result.try(
+    case bit_array.base64_url_encode(decoded_body, False) == encoded_body {
+      True -> Ok(Nil)
+      False ->
+        Error(InvalidTokenFormat("Token body has invalid base64url encoding"))
+    },
+  )
+  use footer_bytes: BitArray <- result.try(
+    result.map_error(pae.decode_footer(encoded_footer), fn(message) {
+      InvalidTokenFormat(message)
+    }),
+  )
+  use #(nonce, ciphertext, authentication_tag) <- result.try(
+    parse_local_token_body(decoded_body),
+  )
+
+  // Derive the same encryption key, counter nonce, and authentication key that
+  // were used during encryption, using the nonce embedded in the token.
+  use #(encryption_key, counter_nonce, authentication_key) <- result.try(
+    result.map_error(derive_local_keys(master_key, nonce), fn(message) {
+      UnexpectedDecryptionError(message)
+    }),
+  )
+
+  // Verify the authentication tag before decrypting. This authenticate-then-
+  // decrypt ordering prevents padding oracle and chosen-ciphertext attacks.
+  let pre_authentication_data: BitArray =
+    pae.pre_auth_encode([
+      bit_array.from_string(local_header),
+      nonce,
+      ciphertext,
+      footer_bytes,
+      bit_array.from_string(implicit_assertion),
+    ])
+  let computed_tag: BitArray =
+    crypto.hmac(pre_authentication_data, crypto.Sha384, authentication_key)
+  use _ <- result.try(case authentication_tag == computed_tag {
+    True -> Ok(Nil)
+    False -> Error(SecurityError)
+  })
+
+  // Decrypt with AES-256-CTR (CTR mode encryption and decryption are identical)
+  let plaintext: BitArray =
+    gaseto_crypto.crypto_one_time(
+      atom.create("aes_256_ctr"),
+      encryption_key,
+      counter_nonce,
+      ciphertext,
+      False,
+    )
+
+  use payload: String <- result.try(
+    result.map_error(bit_array.to_string(plaintext), fn(_) {
+      InvalidTokenFormat("Decrypted payload is not valid UTF-8")
+    }),
+  )
+  Ok(Token(PasetoV3, Local, payload, pae.footer_bytes_to_option(footer_bytes)))
+}
+
+/// Signs a payload using V3.public (ECDSA P-384 + SHA-384).
+/// secret_key_hex: hex-encoded 48-byte P-384 private key scalar
+/// public_key_hex: hex-encoded 49-byte compressed P-384 public key (02/03 prefix + 48-byte X)
+pub fn encrypt_public(
+  secret_key_hex: String,
+  public_key_hex: String,
+  payload: String,
+  footer: Option(String),
+  implicit_assertion: String,
+) -> Result(Token, GasetoV3Error) {
+  use secret_key: BitArray <- result.try(
+    result.map_error(bit_array.base16_decode(secret_key_hex), fn(_) {
+      InvalidKeyFormat("Could not hex-decode secret key")
+    }),
+  )
+  use _ <- result.try(case bit_array.byte_size(secret_key) {
+    size if size == public_secret_key_size -> Ok(Nil)
+    size ->
+      Error(InvalidKeyFormat(
+        "Secret key must be 48 bytes for P-384, got " <> int.to_string(size),
+      ))
+  })
+  use public_key: BitArray <- result.try(
+    result.map_error(bit_array.base16_decode(public_key_hex), fn(_) {
+      InvalidKeyFormat("Could not hex-decode public key")
+    }),
+  )
+  use _ <- result.try(case bit_array.byte_size(public_key) {
+    size if size == public_key_size -> Ok(Nil)
+    size ->
+      Error(InvalidKeyFormat(
+        "Public key must be 49 bytes (compressed P-384), got "
+        <> int.to_string(size),
+      ))
+  })
+
+  let payload_bytes: BitArray = bit_array.from_string(payload)
+  let footer_bytes: BitArray = case footer {
+    Some(footer_string) -> bit_array.from_string(footer_string)
+    None -> <<>>
+  }
+
+  // The PAE for V3.public binds the compressed public key as the first element,
+  // ensuring the signature is tied to a specific key and cannot be replayed with
+  // a different key that happens to produce the same payload bytes.
+  let signing_input: BitArray =
+    pae.pre_auth_encode([
+      public_key,
+      bit_array.from_string(public_header),
+      payload_bytes,
+      footer_bytes,
+      bit_array.from_string(implicit_assertion),
+    ])
+
+  use signature: BitArray <- result.try(
+    result.map_error(ecdsa.sign_p384(signing_input, secret_key), fn(error) {
+      EcdsaError(error)
+    }),
+  )
+
+  let token_body_bytes: BitArray = bit_array.append(payload_bytes, signature)
+  let token_body_base64: String =
+    bit_array.base64_url_encode(token_body_bytes, False)
+  let token_footer_base64: Option(String) = case footer_bytes {
+    <<>> -> None
+    _ -> Some(bit_array.base64_url_encode(footer_bytes, False))
+  }
+  Ok(Token(PasetoV3, Public, token_body_base64, token_footer_base64))
+}
+
+/// Verifies a V3.public token and extracts the payload.
+/// public_key_hex: hex-encoded 49-byte compressed P-384 public key
+/// encoded_body: base64url-encoded body (without "v3.public." header)
+/// encoded_footer: base64url-encoded footer (without dot separator), if present
+pub fn decrypt_public(
+  public_key_hex: String,
+  encoded_body: String,
+  encoded_footer: Option(String),
+  implicit_assertion: String,
+) -> Result(Token, PasetoV3DecryptError) {
+  use public_key: BitArray <- result.try(
+    result.map_error(bit_array.base16_decode(public_key_hex), fn(_) {
+      InvalidKey("Could not hex-decode public key")
+    }),
+  )
+  use _ <- result.try(case bit_array.byte_size(public_key) {
+    size if size == public_key_size -> Ok(Nil)
+    size ->
+      Error(InvalidKey(
+        "Public key must be 49 bytes (compressed P-384), got "
+        <> int.to_string(size),
+      ))
+  })
+  use decoded_body: BitArray <- result.try(
+    result.map_error(bit_array.base64_url_decode(encoded_body), fn(_) {
+      InvalidTokenFormat("Token body is not valid base64url")
+    }),
+  )
+  use footer_bytes: BitArray <- result.try(
+    result.map_error(pae.decode_footer(encoded_footer), fn(message) {
+      InvalidTokenFormat(message)
+    }),
+  )
+
+  // V3.public token body structure: payload || signature (96 bytes)
+  let decoded_body_size: Int = bit_array.byte_size(decoded_body)
+  use _ <- result.try(case decoded_body_size < public_signature_size {
+    True ->
+      Error(InvalidTokenFormat(
+        "Token body too short to contain signature: "
+        <> int.to_string(decoded_body_size),
+      ))
+    False -> Ok(Nil)
+  })
+  use payload_bytes: BitArray <- result.try(
+    result.map_error(
+      bit_array.slice(
+        decoded_body,
+        0,
+        decoded_body_size - public_signature_size,
+      ),
+      fn(_) { InvalidTokenFormat("Could not extract payload") },
+    ),
+  )
+  use signature: BitArray <- result.try(
+    result.map_error(
+      bit_array.slice(
+        decoded_body,
+        decoded_body_size - public_signature_size,
+        public_signature_size,
+      ),
+      fn(_) { InvalidTokenFormat("Could not extract signature") },
+    ),
+  )
+
+  // Reconstruct the signing input and verify
+  let signing_input: BitArray =
+    pae.pre_auth_encode([
+      public_key,
+      bit_array.from_string(public_header),
+      payload_bytes,
+      footer_bytes,
+      bit_array.from_string(implicit_assertion),
+    ])
+
+  case ecdsa.verify_p384(signing_input, signature, public_key) {
+    False ->
+      Error(VerificationFailed("ECDSA P-384 signature verification failed"))
+    True -> {
+      use payload: String <- result.try(
+        result.map_error(bit_array.to_string(payload_bytes), fn(_) {
+          InvalidTokenFormat("Payload is not valid UTF-8")
+        }),
+      )
+      Ok(Token(
+        PasetoV3,
+        Public,
+        payload,
+        pae.footer_bytes_to_option(footer_bytes),
+      ))
+    }
+  }
+}
+
+/// Derives the three local symmetric keys from the master key and nonce using HKDF-SHA384.
+/// Returns #(encryption_key 32 bytes, counter_nonce 16 bytes, authentication_key 48 bytes).
+/// Returns a plain String error so callers can map it into their own error type.
+fn derive_local_keys(
+  master_key: BitArray,
+  nonce: BitArray,
+) -> Result(#(BitArray, BitArray, BitArray), String) {
+  let hash_algorithm: crypto.HashAlgorithm = crypto.Sha384
+
+  // Derive the encryption key (32 bytes) and counter nonce (16 bytes) from a
+  // single 48-byte HKDF output. The info string binds the derived key to this
+  // specific nonce, preventing key reuse across encryptions.
+  let encryption_key_info: BitArray =
+    bit_array.concat([
+      bit_array.from_string("paseto-encryption-key"),
+      nonce,
+    ])
+  use encryption_key_material: BitArray <- result.try(
+    result.map_error(
+      hkdf.hkdf_derive(
+        hash_algorithm,
+        <<>>,
+        master_key,
+        encryption_key_info,
+        local_encryption_key_material_size,
+      ),
+      fn(error) { error.message },
+    ),
+  )
+  use encryption_key: BitArray <- result.try(
+    result.map_error(
+      bit_array.slice(encryption_key_material, 0, local_encryption_key_size),
+      fn(_) { "Could not slice encryption key from HKDF output" },
+    ),
+  )
+  use counter_nonce: BitArray <- result.try(
+    result.map_error(
+      bit_array.slice(
+        encryption_key_material,
+        local_encryption_key_size,
+        local_counter_nonce_size,
+      ),
+      fn(_) { "Could not slice counter nonce from HKDF output" },
+    ),
+  )
+
+  // Derive a separate authentication key so that the HMAC key is never the
+  // same as the encryption key, even for the same master key and nonce.
+  let authentication_key_info: BitArray =
+    bit_array.concat([
+      bit_array.from_string("paseto-auth-key-for-aead"),
+      nonce,
+    ])
+  use authentication_key: BitArray <- result.try(
+    result.map_error(
+      hkdf.hkdf_derive(
+        hash_algorithm,
+        <<>>,
+        master_key,
+        authentication_key_info,
+        local_tag_size,
+      ),
+      fn(error) { error.message },
+    ),
+  )
+
+  Ok(#(encryption_key, counter_nonce, authentication_key))
+}
+
+/// Parses a decoded V3.local token body into its three components.
+/// Token body structure: nonce (32 bytes) || ciphertext || authentication tag (48 bytes).
+fn parse_local_token_body(
+  decoded_body: BitArray,
+) -> Result(#(BitArray, BitArray, BitArray), PasetoV3DecryptError) {
+  let min_body_size: Int = local_nonce_size + local_tag_size
+
+  use body_size: Int <- result.try(case bit_array.byte_size(decoded_body) {
+    size if size < min_body_size ->
+      Error(InvalidTokenFormat(
+        "Token body too short: "
+        <> int.to_string(size)
+        <> ", minimum "
+        <> int.to_string(min_body_size),
+      ))
+    size -> Ok(size)
+  })
+  use nonce: BitArray <- result.try(
+    result.map_error(bit_array.slice(decoded_body, 0, local_nonce_size), fn(_) {
+      InvalidTokenFormat("Could not extract nonce")
+    }),
+  )
+  let ciphertext_size: Int = body_size - local_nonce_size - local_tag_size
+  use ciphertext: BitArray <- result.try(
+    result.map_error(
+      bit_array.slice(decoded_body, local_nonce_size, ciphertext_size),
+      fn(_) { InvalidTokenFormat("Could not extract ciphertext") },
+    ),
+  )
+  use authentication_tag: BitArray <- result.try(
+    result.map_error(
+      bit_array.slice(decoded_body, body_size - local_tag_size, local_tag_size),
+      fn(_) { InvalidTokenFormat("Could not extract authentication tag") },
+    ),
+  )
+  Ok(#(nonce, ciphertext, authentication_tag))
+}

--- a/src/gaseto_ecdsa_ffi.erl
+++ b/src/gaseto_ecdsa_ffi.erl
@@ -1,0 +1,11 @@
+-module(gaseto_ecdsa_ffi).
+-export([sign_p384/2, verify_p384/3]).
+
+%% Signs data using ECDSA with P-384 and SHA-384.
+%% Returns the DER-encoded signature.
+sign_p384(Data, PrivateKey) ->
+    crypto:sign(ecdsa, sha384, Data, [PrivateKey, secp384r1]).
+
+%% Verifies a DER-encoded ECDSA P-384 + SHA-384 signature.
+verify_p384(Data, Signature, PublicKey) ->
+    crypto:verify(ecdsa, sha384, Data, Signature, [PublicKey, secp384r1]).

--- a/test/gaseto/paseto_v1_test.gleam
+++ b/test/gaseto/paseto_v1_test.gleam
@@ -1,4 +1,4 @@
-import gaseto
+import gaseto.{KeyPair, LocalKey}
 import gaseto/paseto_v1_test_vectors
 import gaseto/token.{Local, Public}
 import gleam/io
@@ -9,7 +9,7 @@ pub fn verify_v1_local_decode_test() {
   paseto_v1_test_vectors.paseto_v1_local_test_vectors
   |> list.each(fn(vector) {
     io.println("Testing decode V1 local: " <> vector.name)
-    let assert Ok(token) = gaseto.decrypt(vector.token, vector.key)
+    let assert Ok(token) = gaseto.decrypt(vector.token, LocalKey(vector.key))
     let vector_footer = case vector.footer {
       "" -> option.None
       _ -> option.Some(vector.footer)
@@ -34,14 +34,13 @@ pub fn verify_v1_local_encode_and_decode_test() {
     let assert Ok(encrypted_token) =
       gaseto.encrypt(
         vector.payload,
-        vector.key,
+        LocalKey(vector.key),
         token.PasetoV1,
-        Local,
         vector_footer,
       )
 
     let string_token: String = gaseto.to_string(encrypted_token)
-    let assert Ok(token) = gaseto.decrypt(string_token, vector.key)
+    let assert Ok(token) = gaseto.decrypt(string_token, LocalKey(vector.key))
 
     assert token.payload == vector.payload
     assert token.footer == vector_footer
@@ -56,7 +55,11 @@ pub fn verify_v1_public_decode_test() {
   paseto_v1_test_vectors.paseto_v1_public_test_vectors
   |> list.each(fn(vector) {
     io.println("Testing decode V1 public: " <> vector.name)
-    let assert Ok(token) = gaseto.decrypt(vector.token, vector.public_key)
+    let assert Ok(token) =
+      gaseto.decrypt(
+        vector.token,
+        KeyPair(secret_key: vector.secret_key, public_key: vector.public_key),
+      )
     let vector_footer = case vector.footer {
       "" -> option.None
       _ -> option.Some(vector.footer)
@@ -78,16 +81,12 @@ pub fn verify_v1_public_encode_and_decode_test() {
       "" -> option.None
       _ -> option.Some(vector.footer)
     }
-    let assert Ok(encrypted_token) =
-      gaseto.encrypt(
-        vector.payload,
-        vector.secret_key,
-        token.PasetoV1,
-        Public,
-        vector_footer,
-      )
-    let string_token: String = gaseto.to_string(encrypted_token)
-    let assert Ok(token) = gaseto.decrypt(string_token, vector.public_key)
+    let key_pair =
+      KeyPair(secret_key: vector.secret_key, public_key: vector.public_key)
+    let assert Ok(signed_token) =
+      gaseto.encrypt(vector.payload, key_pair, token.PasetoV1, vector_footer)
+    let string_token: String = gaseto.to_string(signed_token)
+    let assert Ok(token) = gaseto.decrypt(string_token, key_pair)
 
     assert token.payload == vector.payload
     assert token.footer == vector_footer
@@ -100,46 +99,39 @@ pub fn verify_v1_public_encode_and_decode_test() {
   })
 }
 
-pub fn verify_v1_local_with_public_key_pair_decode_test() {
+// Passing an RSA PEM key as a LocalKey should fail — it is not a valid
+// hex-encoded 32-byte AES key.
+pub fn verify_v1_local_wrong_key_material_encode_test() {
   let vector = paseto_v1_test_vectors.paseto_v1_local_test_vector_with_rsa_keys
-  let assert Error(_) = gaseto.decrypt(vector.token, vector.public_key)
+  let assert Error(_) =
+    gaseto.encrypt(vector.payload, LocalKey(vector.public_key), token.PasetoV1, option.None)
 }
 
-pub fn verify_v1_local_with_public_key_pair_encode_test() {
+pub fn verify_v1_local_wrong_key_material_decode_test() {
   let vector = paseto_v1_test_vectors.paseto_v1_local_test_vector_with_rsa_keys
-  let vector_footer = case vector.footer {
-    "" -> option.None
-    _ -> option.Some(vector.footer)
-  }
   let assert Error(_) =
-    gaseto.encrypt(
-      vector.payload,
-      vector.secret_key,
-      token.PasetoV1,
-      Local,
-      vector_footer,
+    gaseto.decrypt(
+      vector.token,
+      KeyPair(secret_key: vector.secret_key, public_key: vector.public_key),
     )
 }
 
-pub fn verify_v1_public_with_local_key_decode_test() {
+// Passing a 32-byte symmetric key as a KeyPair should fail — it is not a
+// valid RSA private key.
+pub fn verify_v1_public_wrong_key_material_encode_test() {
   let vector =
     paseto_v1_test_vectors.paseto_v1_public_test_bector_with_local_key
-  let assert Error(_) = gaseto.decrypt(vector.token, vector.key)
-}
-
-pub fn verify_v1_public_with_local_key_encode_test() {
-  let vector =
-    paseto_v1_test_vectors.paseto_v1_public_test_bector_with_local_key
-  let vector_footer = case vector.footer {
-    "" -> option.None
-    _ -> option.Some(vector.footer)
-  }
   let assert Error(_) =
     gaseto.encrypt(
       vector.payload,
-      vector.key,
+      KeyPair(secret_key: vector.key, public_key: vector.key),
       token.PasetoV1,
-      Public,
-      vector_footer,
+      option.None,
     )
+}
+
+pub fn verify_v1_public_wrong_key_material_decode_test() {
+  let vector =
+    paseto_v1_test_vectors.paseto_v1_public_test_bector_with_local_key
+  let assert Error(_) = gaseto.decrypt(vector.token, LocalKey(vector.key))
 }

--- a/test/gaseto/paseto_v3_test.gleam
+++ b/test/gaseto/paseto_v3_test.gleam
@@ -1,0 +1,142 @@
+import gaseto.{LocalKey}
+import gaseto/paseto_v3
+import gaseto/paseto_v3_test_vectors
+import gaseto/token.{Local, Public}
+import gleam/io
+import gleam/list
+import gleam/option
+import gleam/string
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+/// Extracts the base64url payload and optional base64url footer from a full PASETO token string.
+fn parse_token_body(token_string: String) -> #(String, option.Option(String)) {
+  case string.split(token_string, ".") {
+    [_, _, payload] -> #(payload, option.None)
+    [_, _, payload, footer] -> #(payload, option.Some(footer))
+    _ -> #("", option.None)
+  }
+}
+
+fn option_from_string(s: String) -> option.Option(String) {
+  case s {
+    "" -> option.None
+    _ -> option.Some(s)
+  }
+}
+
+// ─── Local (V3.local) Tests ─────────────────────────────────────────────────
+
+pub fn verify_v3_local_decode_test() {
+  paseto_v3_test_vectors.paseto_v3_local_test_vectors
+  |> list.each(fn(vector) {
+    io.println("Testing decode V3 local: " <> vector.name)
+    let #(payload_b64, footer_b64) = parse_token_body(vector.token)
+    let assert Ok(tok) =
+      paseto_v3.decrypt_local(
+        vector.key,
+        payload_b64,
+        footer_b64,
+        vector.implicit_assertion,
+      )
+    let expected_footer = option_from_string(vector.footer)
+    assert tok.payload == vector.payload
+    assert tok.footer == expected_footer
+    assert tok.purpose == Local
+    assert tok.version == token.PasetoV3
+    io.println("Testing decode V3 local: " <> vector.name <> " | Passed")
+  })
+}
+
+pub fn verify_v3_local_encode_and_decode_test() {
+  // Round-trip test: encrypt with a random nonce, then decrypt, check payload.
+  // Only vectors with no implicit assertion can use the gaseto public API (which passes "" implicitly).
+  paseto_v3_test_vectors.paseto_v3_local_test_vectors
+  |> list.filter(fn(v) { v.implicit_assertion == "" })
+  |> list.each(fn(vector) {
+    io.println("Testing encode/decode V3 local: " <> vector.name)
+    let footer_option = option_from_string(vector.footer)
+    let assert Ok(encrypted_token) =
+      gaseto.encrypt(
+        vector.payload,
+        LocalKey(vector.key),
+        token.PasetoV3,
+        footer_option,
+      )
+    let token_string = gaseto.to_string(encrypted_token)
+    let assert Ok(decrypted) = gaseto.decrypt(token_string, LocalKey(vector.key))
+    assert decrypted.payload == vector.payload
+    assert decrypted.footer == footer_option
+    assert decrypted.purpose == Local
+    assert decrypted.version == token.PasetoV3
+    io.println(
+      "Testing encode/decode V3 local: " <> vector.name <> " | Passed",
+    )
+  })
+}
+
+// ─── Public (V3.public) Tests ────────────────────────────────────────────────
+
+pub fn verify_v3_public_decode_test() {
+  paseto_v3_test_vectors.paseto_v3_public_test_vectors
+  |> list.each(fn(vector) {
+    io.println("Testing decode V3 public: " <> vector.name)
+    let #(payload_b64, footer_b64) = parse_token_body(vector.token)
+    let assert Ok(tok) =
+      paseto_v3.decrypt_public(
+        vector.public_key,
+        payload_b64,
+        footer_b64,
+        vector.implicit_assertion,
+      )
+    let expected_footer = option_from_string(vector.footer)
+    assert tok.payload == vector.payload
+    assert tok.footer == expected_footer
+    assert tok.purpose == Public
+    assert tok.version == token.PasetoV3
+    io.println("Testing decode V3 public: " <> vector.name <> " | Passed")
+  })
+}
+
+pub fn verify_v3_public_sign_and_verify_test() {
+  paseto_v3_test_vectors.paseto_v3_public_test_vectors
+  |> list.each(fn(vector) {
+    io.println("Testing sign/verify V3 public: " <> vector.name)
+    let footer_option = option_from_string(vector.footer)
+    let assert Ok(signed_token) =
+      paseto_v3.encrypt_public(
+        vector.secret_key,
+        vector.public_key,
+        vector.payload,
+        footer_option,
+        vector.implicit_assertion,
+      )
+    let token_string = gaseto.to_string(signed_token)
+    let #(payload_b64, footer_b64) = parse_token_body(token_string)
+    let assert Ok(verified) =
+      paseto_v3.decrypt_public(
+        vector.public_key,
+        payload_b64,
+        footer_b64,
+        vector.implicit_assertion,
+      )
+    assert verified.payload == vector.payload
+    assert verified.footer == footer_option
+    assert verified.purpose == Public
+    assert verified.version == token.PasetoV3
+    io.println(
+      "Testing sign/verify V3 public: " <> vector.name <> " | Passed",
+    )
+  })
+}
+
+// ─── Failure Cases ───────────────────────────────────────────────────────────
+
+pub fn verify_v3_failure_cases_test() {
+  paseto_v3_test_vectors.paseto_v3_fail_test_vectors
+  |> list.each(fn(vector) {
+    io.println("Testing failure case: " <> vector.name)
+    let assert Error(_) = gaseto.decrypt(vector.token, LocalKey(vector.key))
+    io.println("Testing failure case: " <> vector.name <> " | Passed")
+  })
+}

--- a/test/gaseto/paseto_v3_test_vectors.gleam
+++ b/test/gaseto/paseto_v3_test_vectors.gleam
@@ -1,0 +1,192 @@
+pub type PasetoV3LocalTestVector {
+  PasetoV3LocalTestVector(
+    name: String,
+    key: String,
+    nonce: String,
+    token: String,
+    payload: String,
+    footer: String,
+    implicit_assertion: String,
+  )
+}
+
+pub type PasetoV3PublicTestVector {
+  PasetoV3PublicTestVector(
+    name: String,
+    public_key: String,
+    secret_key: String,
+    token: String,
+    payload: String,
+    footer: String,
+    implicit_assertion: String,
+  )
+}
+
+pub type PasetoV3FailTestVector {
+  PasetoV3FailTestVector(
+    name: String,
+    key: String,
+    token: String,
+    footer: String,
+    implicit_assertion: String,
+  )
+}
+
+pub const paseto_v3_local_test_vectors = [
+  PasetoV3LocalTestVector(
+    name: "3-E-1",
+    key: "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+    nonce: "0000000000000000000000000000000000000000000000000000000000000000",
+    token: "v3.local.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADbfcIURX_0pVZVU1mAESUzrKZAsRm2EsD6yBoZYn6cpVZNzSJOhSDN-sRaWjfLU-yn9OJH1J_B8GKtOQ9gSQlb8yk9Iza7teRdkiR89ZFyvPPsVjjFiepFUVcMa-LP18zV77f_crJrVXWa5PDNRkCSeHfBBeg",
+    payload: "{\"data\":\"this is a secret message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+    footer: "",
+    implicit_assertion: "",
+  ),
+  PasetoV3LocalTestVector(
+    name: "3-E-2",
+    key: "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+    nonce: "0000000000000000000000000000000000000000000000000000000000000000",
+    token: "v3.local.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADbfcIURX_0pVZVU1mAESUzrKZAqhWxBMDgyBoZYn6cpVZNzSJOhSDN-sRaWjfLU-yn9OJH1J_B8GKtOQ9gSQlb8yk9IzZfaZpReVpHlDSwfuygx1riVXYVs-UjcrG_apl9oz3jCVmmJbRuKn5ZfD8mHz2db0A",
+    payload: "{\"data\":\"this is a hidden message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+    footer: "",
+    implicit_assertion: "",
+  ),
+  PasetoV3LocalTestVector(
+    name: "3-E-3",
+    key: "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+    nonce: "26f7553354482a1d91d4784627854b8da6b8042a7966523c2b404e8dbbe7f7f2",
+    token: "v3.local.JvdVM1RIKh2R1HhGJ4VLjaa4BCp5ZlI8K0BOjbvn9_LwY78vQnDait-Q-sjhF88dG2B0ROIIykcrGHn8wzPbTrqObHhyoKpjy3cwZQzLdiwRsdEK5SDvl02_HjWKJW2oqGMOQJlxnt5xyhQjFJomwnt7WW_7r2VT0G704ifult011-TgLCyQ2X8imQhniG_hAQ4BydM",
+    payload: "{\"data\":\"this is a secret message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+    footer: "",
+    implicit_assertion: "",
+  ),
+  PasetoV3LocalTestVector(
+    name: "3-E-4",
+    key: "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+    nonce: "26f7553354482a1d91d4784627854b8da6b8042a7966523c2b404e8dbbe7f7f2",
+    token: "v3.local.JvdVM1RIKh2R1HhGJ4VLjaa4BCp5ZlI8K0BOjbvn9_LwY78vQnDait-Q-sjhF88dG2B0X-4P3EcxGHn8wzPbTrqObHhyoKpjy3cwZQzLdiwRsdEK5SDvl02_HjWKJW2oqGMOQJlBZa_gOpVj4gv0M9lV6Pwjp8JS_MmaZaTA1LLTULXybOBZ2S4xMbYqYmDRhh3IgEk",
+    payload: "{\"data\":\"this is a hidden message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+    footer: "",
+    implicit_assertion: "",
+  ),
+  PasetoV3LocalTestVector(
+    name: "3-E-5",
+    key: "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+    nonce: "26f7553354482a1d91d4784627854b8da6b8042a7966523c2b404e8dbbe7f7f2",
+    token: "v3.local.JvdVM1RIKh2R1HhGJ4VLjaa4BCp5ZlI8K0BOjbvn9_LwY78vQnDait-Q-sjhF88dG2B0ROIIykcrGHn8wzPbTrqObHhyoKpjy3cwZQzLdiwRsdEK5SDvl02_HjWKJW2oqGMOQJlkYSIbXOgVuIQL65UMdW9WcjOpmqvjqD40NNzed-XPqn1T3w-bJvitYpUJL_rmihc.eyJraWQiOiJVYmtLOFk2aXY0R1poRnA2VHgzSVdMV0xmTlhTRXZKY2RUM3pkUjY1WVp4byJ9",
+    payload: "{\"data\":\"this is a secret message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+    footer: "{\"kid\":\"UbkK8Y6iv4GZhFp6Tx3IWLWLfNXSEvJcdT3zdR65YZxo\"}",
+    implicit_assertion: "",
+  ),
+  PasetoV3LocalTestVector(
+    name: "3-E-6",
+    key: "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+    nonce: "26f7553354482a1d91d4784627854b8da6b8042a7966523c2b404e8dbbe7f7f2",
+    token: "v3.local.JvdVM1RIKh2R1HhGJ4VLjaa4BCp5ZlI8K0BOjbvn9_LwY78vQnDait-Q-sjhF88dG2B0X-4P3EcxGHn8wzPbTrqObHhyoKpjy3cwZQzLdiwRsdEK5SDvl02_HjWKJW2oqGMOQJmSeEMphEWHiwtDKJftg41O1F8Hat-8kQ82ZIAMFqkx9q5VkWlxZke9ZzMBbb3Znfo.eyJraWQiOiJVYmtLOFk2aXY0R1poRnA2VHgzSVdMV0xmTlhTRXZKY2RUM3pkUjY1WVp4byJ9",
+    payload: "{\"data\":\"this is a hidden message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+    footer: "{\"kid\":\"UbkK8Y6iv4GZhFp6Tx3IWLWLfNXSEvJcdT3zdR65YZxo\"}",
+    implicit_assertion: "",
+  ),
+  PasetoV3LocalTestVector(
+    name: "3-E-7",
+    key: "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+    nonce: "26f7553354482a1d91d4784627854b8da6b8042a7966523c2b404e8dbbe7f7f2",
+    token: "v3.local.JvdVM1RIKh2R1HhGJ4VLjaa4BCp5ZlI8K0BOjbvn9_LwY78vQnDait-Q-sjhF88dG2B0ROIIykcrGHn8wzPbTrqObHhyoKpjy3cwZQzLdiwRsdEK5SDvl02_HjWKJW2oqGMOQJkzWACWAIoVa0bz7EWSBoTEnS8MvGBYHHo6t6mJunPrFR9JKXFCc0obwz5N-pxFLOc.eyJraWQiOiJVYmtLOFk2aXY0R1poRnA2VHgzSVdMV0xmTlhTRXZKY2RUM3pkUjY1WVp4byJ9",
+    payload: "{\"data\":\"this is a secret message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+    footer: "{\"kid\":\"UbkK8Y6iv4GZhFp6Tx3IWLWLfNXSEvJcdT3zdR65YZxo\"}",
+    implicit_assertion: "{\"test-vector\":\"3-E-7\"}",
+  ),
+  PasetoV3LocalTestVector(
+    name: "3-E-8",
+    key: "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+    nonce: "26f7553354482a1d91d4784627854b8da6b8042a7966523c2b404e8dbbe7f7f2",
+    token: "v3.local.JvdVM1RIKh2R1HhGJ4VLjaa4BCp5ZlI8K0BOjbvn9_LwY78vQnDait-Q-sjhF88dG2B0X-4P3EcxGHn8wzPbTrqObHhyoKpjy3cwZQzLdiwRsdEK5SDvl02_HjWKJW2oqGMOQJmZHSSKYR6AnPYJV6gpHtx6dLakIG_AOPhu8vKexNyrv5_1qoom6_NaPGecoiz6fR8.eyJraWQiOiJVYmtLOFk2aXY0R1poRnA2VHgzSVdMV0xmTlhTRXZKY2RUM3pkUjY1WVp4byJ9",
+    payload: "{\"data\":\"this is a hidden message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+    footer: "{\"kid\":\"UbkK8Y6iv4GZhFp6Tx3IWLWLfNXSEvJcdT3zdR65YZxo\"}",
+    implicit_assertion: "{\"test-vector\":\"3-E-8\"}",
+  ),
+  PasetoV3LocalTestVector(
+    name: "3-E-9",
+    key: "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+    nonce: "26f7553354482a1d91d4784627854b8da6b8042a7966523c2b404e8dbbe7f7f2",
+    token: "v3.local.JvdVM1RIKh2R1HhGJ4VLjaa4BCp5ZlI8K0BOjbvn9_LwY78vQnDait-Q-sjhF88dG2B0X-4P3EcxGHn8wzPbTrqObHhyoKpjy3cwZQzLdiwRsdEK5SDvl02_HjWKJW2oqGMOQJlk1nli0_wijTH_vCuRwckEDc82QWK8-lG2fT9wQF271sgbVRVPjm0LwMQZkvvamqU.YXJiaXRyYXJ5LXN0cmluZy10aGF0LWlzbid0LWpzb24",
+    payload: "{\"data\":\"this is a hidden message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+    footer: "arbitrary-string-that-isn't-json",
+    implicit_assertion: "{\"test-vector\":\"3-E-9\"}",
+  ),
+]
+
+pub const paseto_v3_public_test_vectors = [
+  PasetoV3PublicTestVector(
+    name: "3-S-1",
+    public_key: "02fbcb7c69ee1c60579be7a334134878d9c5c5bf35d552dab63c0140397ed14cef637d7720925c44699ea30e72874c72fb",
+    secret_key: "20347609607477aca8fbfbc5e6218455f3199669792ef8b466faa87bdc67798144c848dd03661eed5ac62461340cea96",
+    token: "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9vrarT0tBPumLsUh5iJGDDH7sIkPk1fW8Ej6R2j-8jB7rkkCJyEKxcMNPJ5jLurPvZSzRdLb-Ia_Y2YXavY77xbLzJQJkA_zjJeYrd8mWQ24oOpkts1Css3Xa74cz_j3A",
+    payload: "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+    footer: "",
+    implicit_assertion: "",
+  ),
+  PasetoV3PublicTestVector(
+    name: "3-S-2",
+    public_key: "02fbcb7c69ee1c60579be7a334134878d9c5c5bf35d552dab63c0140397ed14cef637d7720925c44699ea30e72874c72fb",
+    secret_key: "20347609607477aca8fbfbc5e6218455f3199669792ef8b466faa87bdc67798144c848dd03661eed5ac62461340cea96",
+    token: "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9ZWrbGZ6L0MDK72skosUaS0Dz7wJ_2bMcM6tOxFuCasO9GhwHrvvchqgXQNLQQyWzGC2wkr-VKII71AvkLpC8tJOrzJV1cap9NRwoFzbcXjzMZyxQ0wkshxZxx8ImmNWP.eyJraWQiOiJkWWtJU3lseFFlZWNFY0hFTGZ6Rjg4VVpyd2JMb2xOaUNkcHpVSEd3OVVxbiJ9",
+    payload: "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+    footer: "{\"kid\":\"dYkISylxQeecEcHELfzF88UZrwbLolNiCdpzUHGw9Uqn\"}",
+    implicit_assertion: "",
+  ),
+  PasetoV3PublicTestVector(
+    name: "3-S-3",
+    public_key: "02fbcb7c69ee1c60579be7a334134878d9c5c5bf35d552dab63c0140397ed14cef637d7720925c44699ea30e72874c72fb",
+    secret_key: "20347609607477aca8fbfbc5e6218455f3199669792ef8b466faa87bdc67798144c848dd03661eed5ac62461340cea96",
+    token: "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9FrkqK6FaB39LisqmPmIHLnu5P8zBTdO_EyWqeworXkGMBChHk-ZZWPt2r7qSYpOqWmvf0oBgf9Elx1TKS4a3YKIcaYddPlu6B9w5LT_b76sCqdVDjE5bH8ZgvZ708c48.eyJraWQiOiJkWWtJU3lseFFlZWNFY0hFTGZ6Rjg4VVpyd2JMb2xOaUNkcHpVSEd3OVVxbiJ9",
+    payload: "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
+    footer: "{\"kid\":\"dYkISylxQeecEcHELfzF88UZrwbLolNiCdpzUHGw9Uqn\"}",
+    implicit_assertion: "{\"test-vector\":\"3-S-3\"}",
+  ),
+]
+
+// F-vectors: tokens that should fail to decrypt/verify.
+// key field holds the local hex key (for local tokens) or public-key hex (for F-1 which has a public key).
+pub const paseto_v3_fail_test_vectors = [
+  // 3-F-1: v3.local token but public key provided (wrong key size for local)
+  PasetoV3FailTestVector(
+    name: "3-F-1",
+    key: "02fbcb7c69ee1c60579be7a334134878d9c5c5bf35d552dab63c0140397ed14cef637d7720925c44699ea30e72874c72fb",
+    token: "v3.local.tthw-G1Da_BzYeMu_GEDp-IyQ7jzUCQHxCHRdDY6hQjKg6CuxECXfjOzlmNgNJ-WELjN61gMDnldG9OLkr3wpxuqdZksCzH9Ul16t3pXCLGPoHQ9_l51NOqVmMLbFVZOPhsmdhef9RxJwmqvzQ_Mo_JkYRlrNA.YXJiaXRyYXJ5LXN0cmluZy10aGF0LWlzbid0LWpzb24",
+    footer: "arbitrary-string-that-isn't-json",
+    implicit_assertion: "{\"test-vector\":\"3-F-1\"}",
+  ),
+  // 3-F-2: v3.public token but local key provided (wrong key size for public)
+  PasetoV3FailTestVector(
+    name: "3-F-2",
+    key: "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+    token: "v3.public.eyJpbnZhbGlkIjoidGhpcyBzaG91bGQgbmV2ZXIgZGVjb2RlIn1hbzIBD_EU54TYDTvsN9bbCU1QPo7FDeIhijkkcB9BrVH73XyM3Wwvu1pJaGCOEc0R5DVe9hb1ka1cYBd0goqVHt0NQ2NhPtILz4W36eCCqyU4uV6xDMeLI8ni6r3GnaY.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9",
+    footer: "{\"kid\":\"zVhMiPBP9fRf2snEcT7gFTioeA9COcNy9DfgL1W60haN\"}",
+    implicit_assertion: "{\"test-vector\":\"3-F-2\"}",
+  ),
+  // 3-F-3: v4.local token (wrong version - not implemented)
+  PasetoV3FailTestVector(
+    name: "3-F-3",
+    key: "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+    token: "v4.local.1JgN1UG8TFAYS49qsx8rxlwh-9E4ONUm3slJXYi5EibmzxpF0Q-du6gakjuyKCBX8TvnSLOKqCPu8Yh3WSa5yJWigPy33z9XZTJF2HQ9wlLDPtVn_Mu1pPxkTU50ZaBKblJBufRA.YXJiaXRyYXJ5LXN0cmluZy10aGF0LWlzbid0LWpzb24",
+    footer: "arbitrary-string-that-isn't-json",
+    implicit_assertion: "{\"test-vector\":\"3-F-3\"}",
+  ),
+  // 3-F-4: v3.local token with corrupted HMAC tag (last base64 char changed from g to h)
+  PasetoV3FailTestVector(
+    name: "3-F-4",
+    key: "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+    token: "v3.local.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADbfcIURX_0pVZVU1mAESUzrKZAsRm2EsD6yBoZYn6cpVZNzSJOhSDN-sRaWjfLU-yn9OJH1J_B8GKtOQ9gSQlb8yk9Iza7teRdkiR89ZFyvPPsVjjFiepFUVcMa-LP18zV77f_crJrVXWa5PDNRkCSeHfBBeh",
+    footer: "",
+    implicit_assertion: "",
+  ),
+  // 3-F-5: v3.local token with illegal padding character '=' in base64url
+  PasetoV3FailTestVector(
+    name: "3-F-5",
+    key: "707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f",
+    token: "v3.local.JvdVM1RIKh2R1HhGJ4VLjaa4BCp5ZlI8K0BOjbvn9_LwY78vQnDait-Q-sjhF88dG2B0ROIIykcrGHn8wzPbTrqObHhyoKpjy3cwZQzLdiwRsdEK5SDvl02_HjWKJW2oqGMOQJlkYSIbXOgVuIQL65UMdW9WcjOpmqvjqD40NNzed-XPqn1T3w-bJvitYpUJL_rmihc=.eyJraWQiOiJVYmtLOFk2aXY0R1poRnA2VHgzSVdMV0xmTlhTRXZKY2RUM3pkUjY1WVp4byJ9",
+    footer: "{\"kid\":\"UbkK8Y6iv4GZhFp6Tx3IWLWLfNXSEvJcdT3zdR65YZxo\"}",
+    implicit_assertion: "",
+  ),
+]


### PR DESCRIPTION
implement v3 handling for both encrypt and decrypt code paths. Return
appropriate Ok/Error variants from the paseto_v3 module and map errors
to library-level EncodeTokenError/DecodeTokenError. This enables using
v3 tokens through gaseto.encrypt/decrypt.

Add test vectors and unit tests for Paseto v3 local mode:
- paseto_v3_local_test_vectors with a sample test vector.
- tests to verify v3 local decode and round-trip encode/decode.

Fixes: integrate v3 support and provide basic verification to ensure
encoding/decoding behaves as expected.